### PR TITLE
Convert this provider to a data source to suppress the diff

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -1,11 +1,10 @@
 package main
 
 import (
+	"compress/flate"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
-
-	//"compress/gzip"
-	"compress/flate"
 )
 
 func Provider() terraform.ResourceProvider {
@@ -18,11 +17,16 @@ func Provider() terraform.ResourceProvider {
 				Description: "The amount of compression to use: NoCompression, BestSpeed, BestCompression or DefaultCompression",
 			},
 		},
-		ResourcesMap: map[string]*schema.Resource{
-			"gzip_me": resourceGzipme(),
+		DataSourcesMap: map[string]*schema.Resource{
+			"gzip_me": dataSourceGzip(),
 		},
-		DataSourcesMap: map[string]*schema.Resource{},
-		ConfigureFunc:  configurefunc,
+		ResourcesMap: map[string]*schema.Resource{
+			"gzip_me": schema.DataSourceResourceShim(
+				"gzip_me",
+				dataSourceGzip(),
+			),
+		},
+		ConfigureFunc: configurefunc,
 	}
 }
 

--- a/resource_gzipme.go
+++ b/resource_gzipme.go
@@ -11,12 +11,10 @@ import (
 	"io"
 )
 
-func resourceGzipme() *schema.Resource {
+func dataSourceGzip() *schema.Resource {
 	return &schema.Resource{
-		Create: createGzipme,
-		Read:   readGzipme,
-		//Update: updateGzipme,
-		Delete: deleteGzipme,
+		Read: readGzipme,
+
 		Schema: map[string]*schema.Schema{
 			"input": &schema.Schema{
 				Type:     schema.TypeString,
@@ -32,48 +30,25 @@ func resourceGzipme() *schema.Resource {
 	}
 }
 
-func createGzipme(d *schema.ResourceData, gzipper interface{}) error {
-	result, err := handleinput(d, gzipper.(*GZipper))
-	if err != nil {
-		return err
-	} else {
-		d.SetId(hash(result))
-		return d.Set("output", result)
-	}
-}
-
 func readGzipme(d *schema.ResourceData, gzipper interface{}) error {
 	result, err := handleinput(d, gzipper.(*GZipper))
 	if err != nil {
 		return err
-	} else {
-		d.SetId(hash(result))
-		return d.Set("output", result)
 	}
-}
 
-func updateGzipme(d *schema.ResourceData, gzipper interface{}) error {
-	result, err := handleinput(d, gzipper.(*GZipper))
-	if err != nil {
-		return err
-	} else {
-		d.SetId(hash(result))
-		return d.Set("output", result)
-	}
-}
-
-func deleteGzipme(d *schema.ResourceData, gzipper interface{}) error {
+	d.Set("output", result)
+	d.SetId(hash(result))
 	return nil
 }
 
-func handleinput(d *schema.ResourceData, g *GZipper) (string, error) {
-	data_in := d.Get("input").(string)
+func handleinput(d *schema.ResourceData, gzipper *GZipper) (string, error) {
+	dataIn := d.Get("input").(string)
 	gzbuffer := bytes.Buffer{}
-	gzw, err := gzip.NewWriterLevel(&gzbuffer, g.CompressionLevel)
+	gzw, err := gzip.NewWriterLevel(&gzbuffer, gzipper.CompressionLevel)
 	if err != nil {
 		return "", err
 	}
-	if _, err := gzw.Write([]byte(data_in)); err != nil {
+	if _, err := gzw.Write([]byte(dataIn)); err != nil {
 		return "", err
 	}
 	gzw.Close()
@@ -85,7 +60,7 @@ func handleinput(d *schema.ResourceData, g *GZipper) (string, error) {
 		return "", err
 	}
 	b64w.Close()
-	return string(b64buffer.Bytes()), nil
+	return b64buffer.String(), nil
 }
 
 func hash(s string) string {


### PR DESCRIPTION
This PR proposes a fix for #2. Hopefully Terraform will acquire this functionality natively.

Before this PR, my terraform output when I changed cloud-configs was unreadable.
This makes terraform output readable again :)