### PR TITLE
remove binary from source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ A simple plugin that gzips and base64 encodes whatever is passed to it as input.
 
 To install the plugin:
 
+    go get github.com/jakexks/terraform-provider-gzip
+
+
 Edit ~/.terraformrc
 ```
 providers {


### PR DESCRIPTION
Remove the compiled binary from source control. Having the binary checked in causes issues when using `go get` if you are using a different version of go (1.7.x) and different version of terraform (0.8.1)
Also, update readme with instructions to `go get`